### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "dereckson/wp-cli-polylang",
-    "type": "command",
+    "type": "wp-cli-package",
     "description": "Add a `wp polylang` command to support the Polylang plug-in",
     "keywords": [
         "wp-cli",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
