### PR TITLE
Fix php7 and polylang path changes

### DIFF
--- a/PolylangHelperFunctions.php
+++ b/PolylangHelperFunctions.php
@@ -34,7 +34,7 @@ function pll_get_languages_list () {
  */
 function pll_get_default_language_information($language_code) {
 	global $polylang;
-	require(PLL_ADMIN_INC.'/languages.php');
+	require(PLL_SETTINGS_INC.'/languages.php');
 	foreach ($languages as $language) {
 		if ($language[0] == $language_code || $language[1] == $language_code) {
 			$rtl = (count($language) > 3) && ($language[3] == 'rtl');

--- a/PolylangHelperFunctions.php
+++ b/PolylangHelperFunctions.php
@@ -75,11 +75,11 @@ function pll_add_language($language_code, $language_order = 0, &$error_code = 0)
 	$info = pll_get_default_language_information($language_code);
 
 	$args = array(
-		name => $info['name'],
-		slug => $info['code'],
-		locale => $info['locale'],
-		rtl => $info['rtl'] ? 1 : 0,
-		term_group => $language_order
+		'name' => $info['name'],
+		'slug' => $info['code'],
+		'locale' => $info['locale'],
+		'rtl' => $info['rtl'] ? 1 : 0,
+		'term_group' => $language_order
 	);
 	$error_code = $adminModel->add_language($args);
 	return $error_code !== 0;

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,20 @@
     ],
     "homepage": "https://github.com/dereckson/wp-cli-polylang",
     "license": "GPLv2",
-    "authors": [{
-        "name": "Sébastien Santoro aka Dereckson",
-        "email": "dereckson@espace-win.org",
-        "homepage": "http://www.dereckson.be",
-        "role": "Developer"
-    }],
+    "authors": [
+        {
+            "name": "Sébastien Santoro aka Dereckson",
+            "email": "dereckson@espace-win.org",
+            "homepage": "http://www.dereckson.be",
+            "role": "Developer"
+        },
+        {
+            "name": "Ville Pietarinen",
+            "email": "ville@geniem.com",
+            "homepage": "http://geniem.com",
+            "role": "Developer"
+        }
+    ],
     "require": {
         "php": ">=5.3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "i18n"
     ],
     "homepage": "https://github.com/dereckson/wp-cli-polylang",
-    "license": "GPLv2",
+    "license": "GPL-2.0",
     "authors": [
         {
             "name": "Sébastien Santoro aka Dereckson",


### PR DESCRIPTION
This fixes:

- the plugin when used with php7
- polylang paths which changed
- composer.json so that it's valid

These changes were done internally by @villepietarinen. I just pushed them here so you can use them too.