### PR TITLE
Fixes

### DIFF
--- a/PolylangHelperFunctions.php
+++ b/PolylangHelperFunctions.php
@@ -34,7 +34,7 @@ function pll_get_languages_list () {
  */
 function pll_get_default_language_information($language_code) {
 	global $polylang;
-	require(PLL_ADMIN_INC.'/languages.php');
+	require(PLL_SETTINGS_INC . '/languages.php');
 	foreach ($languages as $language) {
 		if ($language[0] == $language_code || $language[1] == $language_code) {
 			$rtl = (count($language) > 3) && ($language[3] == 'rtl');
@@ -75,11 +75,11 @@ function pll_add_language($language_code, $language_order = 0, &$error_code = 0)
 	$info = pll_get_default_language_information($language_code);
 
 	$args = array(
-		name => $info['name'],
-		slug => $info['code'],
-		locale => $info['locale'],
-		rtl => $info['rtl'] ? 1 : 0,
-		term_group => $language_order
+		'name' => $info['name'],
+		'slug' => $info['code'],
+		'locale' => $info['locale'],
+		'rtl' => $info['rtl'] ? 1 : 0,
+		'term_group' => $language_order
 	);
 	$error_code = $adminModel->add_language($args);
 	return $error_code !== 0;

--- a/Polylang_Command.php
+++ b/Polylang_Command.php
@@ -16,6 +16,9 @@ if (!defined('WP_CLI')) {
     return;
 }
 
+if(!defined('PLL_ADMIN'))
+	define('PLL_ADMIN', true);
+
 require_once 'PolylangHelperFunctions.php';
 
 /**
@@ -32,6 +35,8 @@ class Polylang_Command extends WP_CLI_Command {
      *
      * @synopsis
      * @alias langs
+     * 
+     * @when after_wp_load
      */
     function languages ($args, $assocArgs) {
         $languages = pll_get_languages_list();
@@ -66,6 +71,8 @@ class Polylang_Command extends WP_CLI_Command {
      *   wp polylang home fr
      *
      * @synopsis [<language-code>]
+     * 
+     * @when after_wp_load
      */
     function home ($args, $assocArgs) {
         $lang = (count($args) == 1) ?  $args[0] : '';
@@ -93,6 +100,8 @@ class Polylang_Command extends WP_CLI_Command {
      *   wp polylang get post 1 fr
      *
      * @synopsis <data-type> <data-id> [<language-code>]
+     * 
+     * @when after_wp_load
      */
     function get($args, $assocArgs) {
         $lang = (count($args) == 2) ?  '' : $args[2];
@@ -134,6 +143,8 @@ class Polylang_Command extends WP_CLI_Command {
      *
      * @synopsis <operation> <language-code> [<order>]
      * @alias lang
+     * 
+     * @when after_wp_load
      */
     function language ($args, $assocArgs) {
         $language_code = $args[1];

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,12 @@
         "email": "dereckson@espace-win.org",
         "homepage": "http://www.dereckson.be",
         "role": "Developer"
+    },
+    {
+        "name": "Mati Kärner",
+        "email": "mati@adaptive.ee",
+        "homepage": "https://www.adaptive.ee",
+        "role": "Developer"
     }],
     "require": {
         "php": ">=5.3.0"


### PR DESCRIPTION
Fixes multiple issues:
- File `languages.php` has been moved into `settings/` in latest Polylang versions. Added quotes around array key decls in `pll_add_language` (eliminates notices).
- Defined constant `PLL_ADMIN=true` so that method calls against `global $polylang` wouldn't fail.